### PR TITLE
Revert "Bump python from 3.12-slim to 3.13-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.12-slim
 
 USER root
 WORKDIR /app


### PR DESCRIPTION
Pyarrow er dependecy her også. Python 3.13 krever pyarrow >= 18